### PR TITLE
feat: fixed point decimal support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added `alter` space support. Allows to altering existing spaces.
 - Support for index ordering.
+- Fixed point decimal support.
 
 ### Changed
 

--- a/tarantool/src/schema/space.rs
+++ b/tarantool/src/schema/space.rs
@@ -85,6 +85,12 @@ pub fn create_space(name: &str, opts: &SpaceCreateOptions) -> Result<Space, Erro
             IntoIterator::into_iter([
                 ("name".into(), Value::Str(f.name.as_str().into())),
                 ("type".into(), Value::Str(f.field_type.as_str().into())),
+                (
+                    "scale".into(),
+                    Value::BigInt(match f.type_params {
+                        space::TypeParams::Scale(s) => s,
+                    }),
+                ),
                 ("is_nullable".into(), Value::Bool(f.is_nullable)),
             ])
             .collect()

--- a/tarantool/src/space.rs
+++ b/tarantool/src/space.rs
@@ -228,12 +228,28 @@ pub enum SpaceType {
 #[deprecated = "Use `space::Field` instead"]
 pub type SpaceFieldFormat = Field;
 
+/// Extra parameters for parametric types like [`FieldType::Decimal32`] etc.
+#[derive(Clone, Debug, Serialize, Deserialize, msgpack::Encode, msgpack::Decode, PartialEq, Eq)]
+#[serde(untagged, rename_all = "snake_case")]
+#[encode(tarantool = "crate")]
+pub enum TypeParams {
+    /// Used by fixed point decimals.
+    Scale(i64),
+}
+
+impl Default for TypeParams {
+    fn default() -> Self {
+        Self::Scale(i64::MAX)
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, msgpack::Encode, msgpack::Decode, PartialEq, Eq)]
 #[encode(tarantool = "crate", as_map)]
 pub struct Field {
     pub name: String, // TODO(gmoshkin): &str
     #[serde(alias = "type")]
     pub field_type: FieldType,
+    pub type_params: TypeParams,
     pub is_nullable: bool,
 }
 
@@ -245,10 +261,12 @@ where
     fn from(args: (S, FieldType, IsNullable)) -> Self {
         let (name, field_type, is_nullable) = args;
         let name = name.into();
+        let type_params = TypeParams::default();
         let is_nullable = is_nullable.is_nullable();
         Self {
             name,
             field_type,
+            type_params,
             is_nullable,
         }
     }
@@ -262,10 +280,12 @@ where
     fn from(args: (S, FieldType)) -> Self {
         let (name, field_type) = args;
         let name = name.into();
+        let type_params = TypeParams::default();
         let is_nullable = false;
         Self {
             name,
             field_type,
+            type_params,
             is_nullable,
         }
     }
@@ -283,6 +303,7 @@ macro_rules! define_constructors {
                 Self {
                     name: name.into(),
                     field_type: $type,
+                    type_params: TypeParams::default(),
                     is_nullable: false,
                 }
             }
@@ -300,6 +321,7 @@ impl Field {
         Self {
             name: name.to_string(),
             field_type: ft,
+            type_params: TypeParams::default(),
             is_nullable: false,
         }
     }
@@ -314,6 +336,21 @@ impl Field {
     #[inline(always)]
     pub fn is_nullable(mut self, is_nullable: bool) -> Self {
         self.is_nullable = is_nullable;
+        self
+    }
+
+    /// Set the scale for the current field. Setting the scale explicitly
+    /// makes sense only if the field is a fixed point decimal. For other
+    /// fields it should keep the default value set by contructors. This
+    /// method captures `self` by value and returns it, so it should be
+    /// used in a builder fashion.
+    /// ```no_run
+    /// use tarantool::space::Field;
+    /// let f = Field::decimal128("middle name").with_scale(22);
+    /// ```
+    #[inline(always)]
+    pub fn with_scale(mut self, scale: i64) -> Self {
+        self.type_params = TypeParams::Scale(scale);
         self
     }
 
@@ -343,6 +380,10 @@ impl Field {
         uint64(FieldType::UInt64)
         float32(FieldType::Float32)
         float64(FieldType::Float64)
+        decimal32(FieldType::Decimal32)
+        decimal64(FieldType::Decimal64)
+        decimal128(FieldType::Decimal128)
+        decimal256(FieldType::Decimal256)
     }
 }
 
@@ -357,31 +398,35 @@ crate::define_str_enum! {
     #![coerce_from_str]
     /// Type of a field in the space format definition.
     pub enum FieldType {
-        Any       = "any",
-        Unsigned  = "unsigned",
-        String    = "string",
-        Number    = "number",
-        Double    = "double",
-        Integer   = "integer",
-        Boolean   = "boolean",
-        Varbinary = "varbinary",
-        Scalar    = "scalar",
-        Decimal   = "decimal",
-        Uuid      = "uuid",
-        Datetime  = "datetime",
-        Interval  = "interval",
-        Array     = "array",
-        Map       = "map",
-        Int8      = "int8",
-        UInt8     = "uint8",
-        Int16     = "int16",
-        UInt16    = "uint16",
-        Int32     = "int32",
-        UInt32    = "uint32",
-        Int64     = "int64",
-        UInt64    = "uint64",
-        Float32   = "float32",
-        Float64   = "float64",
+        Any        = "any",
+        Unsigned   = "unsigned",
+        String     = "string",
+        Number     = "number",
+        Double     = "double",
+        Integer    = "integer",
+        Boolean    = "boolean",
+        Varbinary  = "varbinary",
+        Scalar     = "scalar",
+        Decimal    = "decimal",
+        Uuid       = "uuid",
+        Datetime   = "datetime",
+        Interval   = "interval",
+        Array      = "array",
+        Map        = "map",
+        Int8       = "int8",
+        UInt8      = "uint8",
+        Int16      = "int16",
+        UInt16     = "uint16",
+        Int32      = "int32",
+        UInt32     = "uint32",
+        Int64      = "int64",
+        UInt64     = "uint64",
+        Float32    = "float32",
+        Float64    = "float64",
+        Decimal32  = "decimal32",
+        Decimal64  = "decimal64",
+        Decimal128 = "decimal128",
+        Decimal256 = "decimal256",
     }
 }
 

--- a/tarantool/src/util.rs
+++ b/tarantool/src/util.rs
@@ -124,6 +124,7 @@ impl<'a> From<&'a str> for NumOrStr {
 #[serde(untagged)]
 pub enum Value<'a> {
     Num(u32),
+    BigInt(i64),
     Double(f64),
     Str(Cow<'a, str>),
     Bool(bool),
@@ -133,6 +134,7 @@ impl std::hash::Hash for Value<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match self {
             Self::Num(v) => v.hash(state),
+            Self::BigInt(v) => v.hash(state),
             Self::Double(v) => v.to_bits().hash(state),
             Self::Str(v) => v.hash(state),
             Self::Bool(v) => v.hash(state),

--- a/tests/src/box.rs
+++ b/tests/src/box.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use tarantool::index::{self, IndexOptions, IteratorType};
 use tarantool::sequence::Sequence;
 use tarantool::space::UpdateOps;
-use tarantool::space::{self, Field, Space, SystemSpace};
+use tarantool::space::{self, Field, Space, SystemSpace, TypeParams};
 use tarantool::space::{SpaceCreateOptions, SpaceEngineType, SpaceType};
 use tarantool::test::util::on_scope_exit;
 use tarantool::tuple::Tuple;
@@ -938,6 +938,7 @@ pub fn space_meta() {
             Field {
                 name: "f3".to_string(),
                 field_type: space::FieldType::String,
+                type_params: TypeParams::default(),
                 is_nullable: true,
             },
         ]),


### PR DESCRIPTION
Since tarantool 3.5.0 an extra parameter called `field_type_params` is going to be added to `tuple_field` structure. This patch extends existed `tarantool::space::Field` to support this field too.

Needs for parametric types like `decimal32` etc.